### PR TITLE
feat: add logger setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "robalo"
+name = "revault-gui"
 version = "0.1.0"
 dependencies = [
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "robalo"
+name = "revault-gui"
 version = "0.1.0"
 authors = ["Edouard Paris <m@edouard.paris>"]
 edition = "2018"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,30 @@
 use std::env::VarError;
 use std::path::PathBuf;
+use std::str::FromStr;
 mod revaultd;
 
 extern crate serde;
 extern crate serde_json;
+
+/// logs everything on stdout
+/// `./revault-gui > log.txt`
+fn setup_logger(level: log::LevelFilter) -> Result<(), fern::InitError> {
+    let dispatcher = fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{}[{}][{}] {}",
+                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(level);
+
+    dispatcher.chain(std::io::stdout()).apply()?;
+
+    Ok(())
+}
 
 fn main() {
     let path = match std::env::var("REVAULTD_CONF") {
@@ -13,6 +34,49 @@ fn main() {
             println!("Error: REVAULTD_CONF path has a wrong unicode format");
             std::process::exit(1);
         }
+    };
+
+    let debug = match std::env::var("REVAULTGUI_DEBUG") {
+        Ok(var) => match FromStr::from_str(&var) {
+            Ok(v) => v,
+            Err(_) => {
+                println!("Error: REVAULTGUI_DEBUG must be `false` or `true`");
+                std::process::exit(1);
+            }
+        },
+        Err(VarError::NotUnicode(_)) => {
+            println!("Error: REVAULTGUI_DEBUG must be `false` or `true`");
+            std::process::exit(1);
+        }
+        Err(VarError::NotPresent) => false,
+    };
+
+    let varloglevel: Option<log::LevelFilter> = match std::env::var("REVAULTGUI_LOGLEVEL") {
+        Ok(var) => match FromStr::from_str(&var) {
+            Ok(v) => Some(v),
+            Err(_) => {
+                println!("Error: REVAULTGUI_LOGLEVEL must be 'OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'");
+                std::process::exit(1);
+            }
+        },
+        Err(VarError::NotUnicode(_)) => {
+            println!("Error: REVAULTGUI_LOGLEVEL must be 'OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'");
+            std::process::exit(1);
+        }
+        Err(VarError::NotPresent) => None,
+    };
+
+    let loglevel = varloglevel.unwrap_or_else(|| {
+        if debug {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Info
+        }
+    });
+
+    if let Err(e) = setup_logger(loglevel) {
+        println!("Error: failed to setup logger: {}", e.to_string());
+        std::process::exit(1);
     };
 
     if let Some(p) = path {

--- a/src/revaultd/client/mod.rs
+++ b/src/revaultd/client/mod.rs
@@ -27,6 +27,7 @@ use uds_windows::UnixStream;
 #[cfg(not(windows))]
 use std::os::unix::net::UnixStream;
 
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -56,7 +57,7 @@ impl Client {
     }
 
     /// Sends a request to a client
-    pub fn send_request<S: Serialize, D: DeserializeOwned>(
+    pub fn send_request<S: Serialize + Debug, D: DeserializeOwned + Debug>(
         &self,
         method: &str,
         params: S,
@@ -72,6 +73,8 @@ impl Client {
             id: std::process::id(),
             jsonrpc: "2.0",
         };
+
+        log::trace!("Sending to revaultd: {:#?}", request);
 
         to_writer(&mut stream, &request)?;
 
@@ -90,6 +93,8 @@ impl Client {
         if response.id != request.id {
             return Err(Error::NonceMismatch);
         }
+
+        log::trace!("Received from revaultd: {:#?}", response);
 
         Ok(response)
     }


### PR DESCRIPTION
__env var:__
`REVAULTGUI_DEBUG` (bool)  is used to specify logger level 
and will be used to enable hecrj/iced debug mode.

__logger:__
Only two log level: debug or default.
example: `REVAULTGUI_DEBUG=true ./revault-gui > log.txt`