### PR TITLE
ui: add clipboard to app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install needed libraries
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libexpat1-dev libxcb-composite0-dev
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.toolchain }} toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,16 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
+dependencies = [
+ "lazy-bytes-cast",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "clipboard-win"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5123c6b97286809fea9e38d2c9bf530edbcb9fc0d8f8272c28b0c95f067fa92d"
@@ -357,6 +367,20 @@ name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+
+[[package]]
+name = "copypasta"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4423d79fed83ebd9ab81ec21fa97144300a961782158287dc9bf7eddac37ff0b"
+dependencies = [
+ "clipboard-win 3.1.1",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "smithay-clipboard",
+ "x11-clipboard",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1455,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-bytes-cast"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2220,7 @@ version = "0.0.1"
 dependencies = [
  "bitcoin",
  "chrono",
+ "copypasta",
  "dirs 3.0.1",
  "iced",
  "serde",
@@ -3133,7 +3164,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0c36ef18b54a244597c90574045c7f2b1dd3027e63287631879cac82e2284a"
 dependencies = [
- "clipboard-win",
+ "clipboard-win 4.0.3",
  "clipboard_macos",
  "clipboard_wayland",
  "clipboard_x11",
@@ -3198,6 +3229,15 @@ checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "x11-clipboard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e937afd03b64b7be4f959cc044e09260a47241b71e56933f37db097bf7859d"
+dependencies = [
+ "xcb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 bitcoin = { version = "0.25.2", features = ["base64"] }
+copypasta = "0.7.1"
 
 iced = { version = "0.2", features = ["tokio", "wgpu", "svg", "debug"] }
 

--- a/src/ui/component/button.rs
+++ b/src/ui/component/button.rs
@@ -1,4 +1,4 @@
-use crate::ui::{color, component::text};
+use crate::ui::{color, component::text, icon::clipboard_icon};
 use iced::{button, Color, Container, Row, Text, Vector};
 
 macro_rules! button {
@@ -56,5 +56,28 @@ pub fn button_content<'a, T: 'a>(icon: Option<iced::Text>, text: &str) -> Contai
                 .align_items(iced::Align::Center),
         )
         .padding(5),
+    }
+}
+
+pub fn clipboard<'a, T: 'a + Clone>(
+    state: &'a mut button::State,
+    message: T,
+) -> button::Button<'a, T> {
+    button::Button::new(state, clipboard_icon().size(15))
+        .on_press(message)
+        .style(ClipboardButtonStyle {})
+}
+
+struct ClipboardButtonStyle {}
+impl button::StyleSheet for ClipboardButtonStyle {
+    fn active(&self) -> button::Style {
+        button::Style {
+            shadow_offset: Vector::default(),
+            background: Color::TRANSPARENT.into(),
+            border_radius: 10.0,
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT.into(),
+            text_color: Color::BLACK.into(),
+        }
     }
 }

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -55,6 +55,10 @@ pub fn dot_icon() -> Text {
     icon('\u{F287}')
 }
 
+pub fn clipboard_icon() -> Text {
+    icon('\u{F28E}')
+}
+
 #[allow(dead_code)]
 pub fn stakeholder_icon() -> Text {
     icon('\u{F4AE}')

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -62,6 +62,7 @@ impl Role {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    Clipboard(String),
     Install,
     ChangeRole(Role),
     Syncing(Result<f64, RevaultDError>),

--- a/src/ui/view/vault.rs
+++ b/src/ui/view/vault.rs
@@ -38,6 +38,7 @@ impl VaultView {
 
 #[derive(Debug)]
 pub struct VaultModal {
+    copy_button: iced::button::State,
     cancel_button: iced::button::State,
     scroll: scrollable::State,
 }
@@ -45,6 +46,7 @@ pub struct VaultModal {
 impl VaultModal {
     pub fn new() -> Self {
         VaultModal {
+            copy_button: iced::button::State::default(),
             cancel_button: iced::button::State::default(),
             scroll: scrollable::State::new(),
         }
@@ -87,7 +89,20 @@ impl VaultModal {
                                                         .push(badge::tx_deposit())
                                                         .push(
                                                             Column::new()
-                                                                .push(text::small(&vlt.txid))
+                                                                .push(
+                                                                    Row::new()
+                                                                        .push(text::small(
+                                                                            &vlt.txid,
+                                                                        ))
+                                                                        .push(button::clipboard(
+                                                                            &mut self.copy_button,
+                                                                            Message::Clipboard(
+                                                                                vlt.txid
+                                                                                    .to_string(),
+                                                                            ),
+                                                                        ))
+                                                                        .align_items(Align::Center),
+                                                                )
                                                                 .push(text::small(&format!(
                                                                     "{}",
                                                                     NaiveDateTime::from_timestamp(


### PR DESCRIPTION
ClipboardContext is added to ui::App
using https://github.com/alacritty/copypasta
which have clipboard support for
Windows, Mac OSX, GNU/Linux, and FreeBSD.

Support was tested with:

- Xorg    | success
- Wayland | failed