### PR TITLE
refac(ui): split message module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::filter::EnvFilter;
 extern crate serde;
 extern crate serde_json;
 
+mod revault;
 mod revaultd;
 mod ui;
 

--- a/src/revault.rs
+++ b/src/revault.rs
@@ -1,0 +1,22 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    Manager,
+    Stakeholder,
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Role::Manager => "Manager",
+                Role::Stakeholder => "Stakeholder",
+            }
+        )
+    }
+}
+
+impl Role {
+    pub const ALL: [Role; 2] = [Role::Manager, Role::Stakeholder];
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6,14 +6,16 @@ use copypasta::{ClipboardContext, ClipboardProvider};
 use iced::{executor, Application, Color, Command, Element, Settings, Subscription};
 use tracing::error;
 
-use super::message::{Menu, Message, Role};
+use super::menu::Menu;
+use super::message::Message;
 use super::state::{
     ChargingState, HistoryState, InstallingState, ManagerHomeState, ManagerNetworkState,
     ManagerSendState, StakeholderHomeState, StakeholderNetworkState, State,
 };
 
+use crate::revault::Role;
 use crate::revaultd::RevaultD;
-use crate::ui::message::Context;
+use crate::ui::view::Context;
 
 pub struct App {
     config: Config,

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Menu {
+    Home,
+    History,
+    Network,
+    Send,
+}

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -1,64 +1,12 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use bitcoin::Network;
-
-use super::error::Error;
+use super::{error::Error, menu::Menu};
+use crate::revault::Role;
 use crate::revaultd::{
     model::{Vault, VaultTransactions},
     RevaultD, RevaultDError,
 };
-
-pub struct Context {
-    pub network: Network,
-    pub network_up: bool,
-    pub menu: Menu,
-    pub role: Role,
-    pub role_edit: bool,
-}
-
-impl Context {
-    pub fn new(role_edit: bool, role: Role, menu: Menu) -> Self {
-        Self {
-            role,
-            role_edit,
-            menu,
-            network: bitcoin::Network::Bitcoin,
-            network_up: false,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Menu {
-    Home,
-    History,
-    Network,
-    Send,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Role {
-    Manager,
-    Stakeholder,
-}
-
-impl std::fmt::Display for Role {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Role::Manager => "Manager",
-                Role::Stakeholder => "Stakeholder",
-            }
-        )
-    }
-}
-
-impl Role {
-    pub const ALL: [Role; 2] = [Role::Manager, Role::Stakeholder];
-}
 
 #[derive(Debug, Clone)]
 pub enum Message {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod font;
 mod icon;
 pub mod image;
+mod menu;
 mod message;
 mod state;
 mod view;

--- a/src/ui/state/charging.rs
+++ b/src/ui/state/charging.rs
@@ -11,8 +11,8 @@ use crate::revaultd::{
 };
 use crate::ui::{
     error::Error,
-    message::{Context, Message},
-    view::charging::*,
+    message::Message,
+    view::{charging::*, Context},
 };
 
 #[derive(Debug, Clone)]

--- a/src/ui/state/history.rs
+++ b/src/ui/state/history.rs
@@ -17,9 +17,8 @@ use crate::revaultd::{
 
 use crate::ui::{
     error::Error,
-    message::{Context, Message},
-    view::vault::VaultView,
-    view::HistoryView,
+    message::Message,
+    view::{vault::VaultView, Context, HistoryView},
 };
 
 #[derive(Debug)]

--- a/src/ui/state/installing.rs
+++ b/src/ui/state/installing.rs
@@ -1,9 +1,9 @@
 use iced::{Command, Element};
 
 use crate::ui::{
-    message::{Context, Message},
+    message::Message,
     state::State,
-    view::installing::installing_view,
+    view::{installing::installing_view, Context},
 };
 
 #[derive(Debug, Clone)]

--- a/src/ui/state/manager.rs
+++ b/src/ui/state/manager.rs
@@ -18,9 +18,10 @@ use crate::revaultd::{
 
 use crate::ui::{
     error::Error,
-    message::{Context, InputMessage, Message, RecipientMessage},
+    message::{InputMessage, Message, RecipientMessage},
     view::manager::{manager_send_input_view, ManagerSendOutputView, ManagerSendView},
     view::vault::VaultView,
+    view::Context,
     view::{ManagerHomeView, ManagerNetworkView},
 };
 

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -14,7 +14,7 @@ pub use installing::InstallingState;
 pub use manager::{ManagerHomeState, ManagerNetworkState, ManagerSendState};
 pub use stakeholder::{StakeholderHomeState, StakeholderNetworkState};
 
-use super::message::{Context, Message};
+use super::{message::Message, view::Context};
 
 pub trait State {
     fn view(&mut self, ctx: &Context) -> Element<Message>;

--- a/src/ui/state/stakeholder.rs
+++ b/src/ui/state/stakeholder.rs
@@ -7,9 +7,9 @@ use crate::revaultd::RevaultD;
 
 use crate::ui::{
     error::Error,
-    message::{Context, Message},
+    message::Message,
     state::{cmd::get_blockheight, util::Watch, State},
-    view::{StakeholderHomeView, StakeholderNetworkView},
+    view::{Context, StakeholderHomeView, StakeholderNetworkView},
 };
 
 #[derive(Debug)]

--- a/src/ui/view/history.rs
+++ b/src/ui/view/history.rs
@@ -3,8 +3,8 @@ use iced::{scrollable, Column, Container, Element, Scrollable};
 use crate::ui::{
     component::navbar,
     error::Error,
-    message::{Context, Message},
-    view::{layout, sidebar::Sidebar},
+    message::Message,
+    view::{layout, sidebar::Sidebar, Context},
 };
 
 #[derive(Debug)]

--- a/src/ui/view/home.rs
+++ b/src/ui/view/home.rs
@@ -3,8 +3,8 @@ use iced::{scrollable, Column, Container, Element, Length, Row, Scrollable};
 use crate::ui::{
     component::{navbar, text},
     error::Error,
-    message::{Context, Message},
-    view::{layout, sidebar::Sidebar},
+    message::Message,
+    view::{layout, sidebar::Sidebar, Context},
 };
 
 #[derive(Debug)]

--- a/src/ui/view/manager.rs
+++ b/src/ui/view/manager.rs
@@ -5,7 +5,8 @@ use iced::{
 
 use crate::ui::{
     component::{button, card, separation, text},
-    message::{InputMessage, Menu, Message, RecipientMessage},
+    menu::Menu,
+    message::{InputMessage, Message, RecipientMessage},
 };
 
 #[derive(Debug)]

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -12,3 +12,28 @@ pub use history::HistoryView;
 pub use home::{ManagerHomeView, StakeholderHomeView};
 pub use manager::ManagerSendView;
 pub use network::{ManagerNetworkView, StakeholderNetworkView};
+
+use bitcoin::Network;
+
+use super::menu::Menu;
+use crate::revault::Role;
+
+pub struct Context {
+    pub network: Network,
+    pub network_up: bool,
+    pub menu: Menu,
+    pub role: Role,
+    pub role_edit: bool,
+}
+
+impl Context {
+    pub fn new(role_edit: bool, role: Role, menu: Menu) -> Self {
+        Self {
+            role,
+            role_edit,
+            menu,
+            network: bitcoin::Network::Bitcoin,
+            network_up: false,
+        }
+    }
+}

--- a/src/ui/view/network.rs
+++ b/src/ui/view/network.rs
@@ -5,8 +5,8 @@ use crate::ui::{
     component::{badge, card, navbar, text},
     error::Error,
     icon::dot_icon,
-    message::{Context, Message},
-    view::{layout, sidebar::Sidebar},
+    message::Message,
+    view::{layout, sidebar::Sidebar, Context},
 };
 
 #[derive(Debug)]

--- a/src/ui/view/sidebar.rs
+++ b/src/ui/view/sidebar.rs
@@ -1,10 +1,12 @@
 use iced::{pick_list, Column, Container, Length, Row};
 
+use crate::revault::Role;
 use crate::ui::{
     component::{button, separation, text, TransparentPickListStyle},
     icon::{dot_icon, history_icon, home_icon, network_icon, send_icon, settings_icon},
-    message::{Context, Menu, Message, Role},
-    view::layout,
+    menu::Menu,
+    message::Message,
+    view::{layout, Context},
 };
 
 #[derive(Debug, Clone)]

--- a/src/ui/view/vault.rs
+++ b/src/ui/view/vault.rs
@@ -4,7 +4,8 @@ use iced::{container, scrollable, Align, Column, Container, Element, Length, Row
 use crate::ui::{
     color,
     component::{badge, button, card, separation, text},
-    message::{Context, Message},
+    message::Message,
+    view::Context,
 };
 
 use crate::revaultd::model::{BroadcastedTransaction, Vault, VaultTransactions};


### PR DESCRIPTION
split message module for clarity.
revault is a new module which will stock user role
transaction kinds and revault constants or enums.
Context is moved to the module using it: view.
Menu is moved in its own module in ui tree.